### PR TITLE
Owning wrapper with iterator interface

### DIFF
--- a/include/Iterator.h
+++ b/include/Iterator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool Iterator_valid(const Iterator* self);
+const void* Iterator_get(const Iterator* self);
+void Iterator_next(Iterator* self);
+void Iterator_release(Iterator* self);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+

--- a/include/Types.h
+++ b/include/Types.h
@@ -51,6 +51,9 @@ typedef struct UnitCommand {
 // Custom type to map functions returning std::string
 typedef struct BwString_ BwString;
 
+typedef struct Iterator_ Iterator;
+typedef struct UnitIterator_ UnitIterator;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/Unit.h
+++ b/include/Unit.h
@@ -87,12 +87,12 @@ Unit* Unit_getAddon(Unit* self);
 Unit* Unit_getNydusExit(Unit* self);
 Unit* Unit_getPowerUp(Unit* self);
 Unit* Unit_getTransport(Unit* self);
-// TODO Unitset getLoadedUnits
+UnitIterator* Unit_getLoadedUnits(Unit* self);
 int Unit_getSpaceRemaining(Unit* self);
 Unit* Unit_getCarrier(Unit* self);
-// TODO Unitset getInterceptors
+UnitIterator* Unit_getInterceptors(Unit* self);
 Unit* Unit_getHatchery(Unit* self);
-// TODO Unitset getLarva
+UnitIterator* Unit_getLarva(Unit* self);
 // TODO Unitset getUnitsInRadius(int radius, const UnitFilter &pred)
 // TODO Unitset getUnitsInWeaponRange(WeaponType weapon, const UnitFilter &pred)
 // TODO Unit* getClosestUnit(const UnitFilter &pred, int radius)

--- a/src/Iterator.cpp
+++ b/src/Iterator.cpp
@@ -1,0 +1,27 @@
+#include "IteratorImpl.hpp"
+#include <BWAPI/Unitset.h>
+
+#include <assert.h>
+
+IteratorBase::~IteratorBase() {
+}
+
+bool Iterator_valid(const Iterator* self) {
+    assert(self);
+    return reinterpret_cast<const IteratorBase*>(self)->valid();
+}
+
+const void* Iterator_get(const Iterator* self) {
+    assert(self);
+    return reinterpret_cast<const IteratorBase*>(self)->get();
+}
+
+void Iterator_next(Iterator* self) {
+    assert(self);
+    reinterpret_cast<IteratorBase*>(self)->next();
+}
+
+void Iterator_release(Iterator* self) {
+    assert(self);
+    delete reinterpret_cast<IteratorBase*>(self);
+}

--- a/src/IteratorImpl.hpp
+++ b/src/IteratorImpl.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <Iterator.h>
+
+// FIXME Probbaly there is something similar in the BWAPI
+enum IteratorType {
+    itUnknown = 0,
+    itUnit,
+};
+
+class IteratorBase {
+public:
+    virtual ~IteratorBase();
+
+    // Can be used for runtime checks
+    virtual IteratorType id() const = 0;
+
+    virtual bool valid() const = 0;
+    virtual const void* get() const = 0;
+    virtual void next() = 0;
+};
+
+template<class Container, IteratorType type>
+class OwningIterator : public IteratorBase {
+public:
+    typedef typename Container::const_iterator Iter;
+
+    OwningIterator(Container container)
+        : container(container), iter(container.begin())
+    {
+        static_assert(type != itUnknown, "Iterator type must be valid");
+    }
+
+    virtual IteratorType id() const override { return type; }
+    virtual bool valid() const override { return iter != container.end(); }
+    virtual const void* get() const override { return &*iter; }
+
+    virtual void next() override {
+        if (iter != container.end())
+            ++iter;
+    }
+
+private:
+    Container container;
+    Iter iter;
+};
+
+template<class T> struct GetIterType {
+    enum { value = itUnknown };
+};
+
+template<> struct GetIterType<UnitIterator> {
+    enum { value = itUnit };
+};
+
+template<class Out, class Container>
+Out* into_iter(Container container) {
+    const auto type = static_cast<IteratorType>(GetIterType<Out>::value);
+    static_assert(type != itUnknown, "Out must be registered, see GetIterType<T>");
+
+    IteratorBase* const iter = new OwningIterator<Container, type>(container);
+    return reinterpret_cast<Out*>(iter);
+}

--- a/src/Unit.cpp
+++ b/src/Unit.cpp
@@ -1,5 +1,6 @@
 #include <Unit.h>
 #include <BWAPI/Unit.h>
+#include <BWAPI/Unitset.h>
 
 #include "Position.hpp"
 #include "Order.hpp"
@@ -7,6 +8,7 @@
 #include "UpgradeType.hpp"
 #include "UnitType.hpp"
 #include "UnitCommand.hpp"
+#include "IteratorImpl.hpp"
 
 int Unit_getID(Unit* self) {
     return reinterpret_cast<BWAPI::Unit>(self)->getID();
@@ -292,6 +294,11 @@ Unit* Unit_getTransport(Unit* self) {
     return reinterpret_cast<Unit*>( reinterpret_cast<BWAPI::Unit>(self)->getTransport() );
 }
 
+UnitIterator* Unit_getLoadedUnits(Unit* self) {
+    const auto units = reinterpret_cast<BWAPI::UnitInterface*>(self)->getLoadedUnits();
+    return into_iter<UnitIterator>(units);
+}
+
 int Unit_getSpaceRemaining(Unit* self) {
     return reinterpret_cast<BWAPI::Unit>(self)->getSpaceRemaining();
 }
@@ -300,8 +307,18 @@ Unit* Unit_getCarrier(Unit* self) {
     return reinterpret_cast<Unit*>( reinterpret_cast<BWAPI::Unit>(self)->getCarrier() );
 }
 
+UnitIterator* Unit_getInterceptors(Unit* self) {
+    const auto interceptors = reinterpret_cast<BWAPI::UnitInterface*>(self)->getInterceptors();
+    return into_iter<UnitIterator>(interceptors);
+}
+
 Unit* Unit_getHatchery(Unit* self) {
     return reinterpret_cast<Unit*>( reinterpret_cast<BWAPI::Unit>(self)->getHatchery() );
+}
+
+UnitIterator* Unit_getLarva(Unit* self) {
+    const auto larva = reinterpret_cast<BWAPI::UnitInterface*>(self)->getLarva();
+    return into_iter<UnitIterator>(larva);
 }
 
 bool Unit_hasNuke(Unit* self) {


### PR DESCRIPTION
Adds container wrapper with iterator interface.
    
In many cases BWAPI returns whole containers instead of references or iterators to them. For example, UnitIterface::getLoadedUnits() returns Unitset.
    
We take ownership over the container object and then provide a generic iterator interface to it. Because of move semantics, container internals are moved, not copied.
    
Also we provide wrapper function and some template magic to deduce mapping between iterator template specialization and it's API counterpart. This helps to avoid interface misuse and makes it more friendly.
