### PR TITLE
Link with OpenBW with cxx11 abi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,37 @@
 language: cpp
 
-compiler:
-  - gcc
-  - clang
+compiler: gcc
 
+os: linux
 dist: trusty
 sudo: false
+
+notifications:
+  email: false
+
 cache:
   apt: true
 addons:
   apt:
+    sources:
+      - sourceline: 'deb http://pl.archive.ubuntu.com/ubuntu xenial main universe'
+      - sourceline: 'deb http://pl.archive.ubuntu.com/ubuntu xenial main'
     packages:
-    - p7zip-full
+      - g++
+      - p7zip-full
   artifacts:
     paths:
-    - $(ls *.zip | tr "\n" ":")
+      - $(ls *.zip | tr "\n" :)
 
 env:
   matrix:
     - BUILD_TYPE=Debug
     - BUILD_TYPE=Release
 
-notifications:
-  email: false
-
-before_install:
-  - mkdir -p $HOME/BWAPI_RELEASES
-  - wget -N https://s3.eu-central-1.amazonaws.com/openbw.bwapi/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz -O $HOME/BWAPI_RELEASES/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz
-  - tar xzf $HOME/BWAPI_RELEASES/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz --directory $HOME/BWAPI_RELEASES
-
 before_script:
+  - mkdir -p $HOME/BWAPI_RELEASES
+  - wget -N https://s3.amazonaws.com/bwapic/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz -O $HOME/BWAPI_RELEASES/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz
+  - tar xzf $HOME/BWAPI_RELEASES/BWAPI-4.1.12-${BUILD_TYPE}-Linux.tar.gz --directory $HOME/BWAPI_RELEASES
   - mkdir -p build
   - cd build
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBWAPI_PATH=$HOME/BWAPI_RELEASES/BWAPI-4.1.12-Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,6 @@ find_package(BWAPI REQUIRED)
 # BWAPIC
 
 file(GLOB_RECURSE BWAPIC_SRC "${CMAKE_SOURCE_DIR}/src/*.cpp")
-if (NOT(MSVC))
-    # FIXME libBWAPIClient.a(Client.cpp.o): unrecognized relocation (0x2a) in section `.text'
-    list(REMOVE_ITEM BWAPIC_SRC ${CMAKE_SOURCE_DIR}/src/Client.cpp)
-endif()
 
 add_library(BWAPIC SHARED ${BWAPIC_SRC})
 target_include_directories(BWAPIC SYSTEM PUBLIC include/ ${BWAPI_INCLUDE_DIRS})
@@ -40,10 +36,8 @@ target_link_libraries(BWAPIC PRIVATE BWAPI BWAPIClient)
 add_library(ExampleDll MODULE example/Dll.c)
 target_link_libraries(ExampleDll BWAPIC)
 
-if (MSVC)
-    add_executable(ExampleClient example/Client.c)
-    target_link_libraries(ExampleClient BWAPIC)
-endif()
+add_executable(ExampleClient example/Client.c)
+target_link_libraries(ExampleClient BWAPIC)
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,39 @@ bwapi-c/build $ make
 
 `BWAPI_PATH` must point to directory with BWAPI release.
 
-# Usage on Linux
+# Usage on Linux with GCC for BWAPILauncher
+You should get `libBWAPIC.so` that was build on Linux with GCC. See [Releases](https://github.com/RnDome/bwapi-c/releases).
+
+### Module
+
+```
+~/bwapi-c/example $ ls
+libBWAPIC.so Dll.c
+~/bwapi-c/example $ gcc -shared -fPIC -o Dll.so Dll.c -I../include -L. -lBWAPIC
+~/bwapi-c/example $ ls
+Dll.c Dll.so libBWAPIC.so
+```
+
+Put `libBWAPIC.so` and `Dll.so` inside `BWAPILauncher` directory, copy `BrooDat.mpq`, `Patch_rt.mpq`, `StarDat.mpq`, `maps` from `StarCraft` directory. Set up `bwapi-data/bwapi.ini` (unset `ai`, `ai_dbg`, set `map`, e.g. `map=maps/BroodWar/ICCup Tau Cross.scx`) and run:
+```
+~/openbw/bwapi/build/bin$ BWAPI_CONFIG_AI__AI=Dll.so BWAPI_CONFIG_AUTO_MENU__RACE=Zerg ./BWAPILauncher
+```
+
+#### Troubleshooting
+
+If you are getting dlerror while injecting your module inside `BWAPILauncher`, recompile `bwapi-c` on you local machine and recompile your `Dll.so`.
+
+Possible errors:
+```
+dlerror: libBWAPIC.so: undefined symbol: _ZNK5BWAPI5Event7getTextB5cxx11Ev
+```
+This is caused by different compiler flags on your machine. `libBWAPIC.so` was built with `--with-default-libstdcxx-abi=new`, and your compiler is probably `--with-default-libstdcxx-abi=gcc4-compatible --disable-libstdcxx-dual-abi`. Recompiling `OpenBW` and `bwapi-c` with the same compiler will fix this problem.
+
+### Client
+
+You may compile it, but it is not supported by OpenBW for now.
+
+# Usage on Linux with MinGW for StarCraft.exe
 You should get `BWAPIC.lib`, `BWAPIC.dll` and `BWAPI.dll` that was build on Windows with MSVC. See [Releases](https://github.com/RnDome/bwapi-c/releases).
 
 ### Module
@@ -29,7 +61,7 @@ You should get `BWAPIC.lib`, `BWAPIC.dll` and `BWAPI.dll` that was build on Wind
 BWAPIC.lib Dll.c
 ~/bwapi-c/example $ i686-w64-mingw32-gcc -mabi=ms -shared -o Dll.dll Dll.c -I../include -L. -lBWAPIC
 ~/bwapi-c/example $ ls
-BWAPIC.lib  Dll.cpp  Dll.dll
+Dll.c Dll.dll BWAPIC.lib
 ```
 
 Put `BWAPIC.dll` inside `StarCraft` directory and `Dll.dll` inside `StarCraft/bwapi-data`.


### PR DESCRIPTION
The compiler we used was with `--with-default-libstdcxx-abi=gcc4-compatible --disable-libstdcxx-dual-abi`, and we need `--with-default-libstdcxx-abi=new`.
